### PR TITLE
Use Java-style instead of Rust-style method naming

### DIFF
--- a/result/src/main/java/com/markelliot/result/Result.java
+++ b/result/src/main/java/com/markelliot/result/Result.java
@@ -114,7 +114,7 @@ public final class Result<T, E> {
      *
      * <p>This function can be used to unpack a successful result while handling an error.
      */
-    public <U> U map_or_else(Function<T, U> resultFn, Function<E, U> errorFn) {
+    public <U> U mapOrElse(Function<T, U> resultFn, Function<E, U> errorFn) {
         if (isOk()) {
             return resultFn.apply(result);
         }

--- a/result/src/test/java/com/markelliot/result/ResultTests.java
+++ b/result/src/test/java/com/markelliot/result/ResultTests.java
@@ -170,8 +170,8 @@ final class ResultTests {
         Result<String, String> ok = Result.ok("hello");
         Result<String, String> error = Result.error("error");
 
-        assertThat(ok.map_or_else(String::length, err -> -1)).isEqualTo(5);
-        assertThat(error.map_or_else(String::length, err -> -1)).isEqualTo(-1);
+        assertThat(ok.mapOrElse(String::length, err -> -1)).isEqualTo(5);
+        assertThat(error.mapOrElse(String::length, err -> -1)).isEqualTo(-1);
     }
 
     @Test


### PR DESCRIPTION
I was using my Rust brain. This should Java-style.